### PR TITLE
Add new syncMethod property for Charts

### DIFF
--- a/demo/component/LineChartSyncId.tsx
+++ b/demo/component/LineChartSyncId.tsx
@@ -1,0 +1,75 @@
+import React, { Component } from 'react';
+import { LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
+
+const data1 = [
+  { name: 'Page A', uv: 400, pv: 2400, amt: 2400 },
+  { name: 'Page B', uv: 300, pv: 4567, amt: 2400 },
+  { name: 'Page C', uv: 300, pv: 1398, amt: 2400 },
+  { name: 'Page D', uv: 200, pv: 9800, amt: 2400 },
+  { name: 'Page E', uv: 278, pv: 3908, amt: 2400 },
+  { name: 'Page F', uv: 189, pv: 4800, amt: 2400 },
+];
+
+// Reversed of data1
+const data2 = [
+  { name: 'Page F', uv: 189, pv: 4800, amt: 2400 },
+  { name: 'Page E', uv: 278, pv: 3908, amt: 2400 },
+  { name: 'Page D', uv: 200, pv: 9800, amt: 2400 },
+  { name: 'Page C', uv: 300, pv: 1398, amt: 2400 },
+  { name: 'Page B', uv: 300, pv: 4567, amt: 2400 },
+  { name: 'Page A', uv: 400, pv: 2400, amt: 2400 },
+];
+
+const margin = { top: 20, right: 20, bottom: 20, left: 20 };
+const height = 400;
+const width = 400;
+
+const initialState = {
+  syncMethod: '',
+};
+
+export default class Demo extends Component<any, any> {
+  static displayName = 'LineChartDemo Sync Method';
+
+  state: any = initialState;
+
+  setSyncMethodToValue = () => {
+    this.setState((prevState: { syncMethod: string }) => ({
+      syncMethod: prevState.syncMethod === 'value' ? 'index' : 'value',
+    }));
+  };
+
+  render() {
+    const { syncMethod } = this.state;
+    return (
+      <div className="line-charts">
+        <button type="button" onClick={this.setSyncMethodToValue}>
+          switch sync Method between value and index
+        </button>
+        <p>
+          Sync Method used:
+          {syncMethod}
+        </p>
+        <p>A simple LineChart with syncId = test</p>
+        <div className="line-chart-wrapper">
+          <LineChart width={width} height={height} data={data1} margin={margin} syncId="test" syncMethod={syncMethod}>
+            <Line isAnimationActive={false} type="monotone" dataKey="uv" stroke="#ff7300" />
+            <Tooltip />
+            <XAxis dataKey="name" />
+            <YAxis />
+          </LineChart>
+        </div>
+
+        <p>A simple LineChart with syncId = test with axis labels in reverse order</p>
+        <div className="line-chart-wrapper">
+          <LineChart width={width} height={height} data={data2} margin={margin} syncId="test" syncMethod={syncMethod}>
+            <Line isAnimationActive={false} type="monotone" dataKey="uv" stroke="#ff7300" />
+            <Tooltip />
+            <XAxis dataKey="name" />
+            <YAxis />
+          </LineChart>
+        </div>
+      </div>
+    );
+  }
+}

--- a/demo/component/index.ts
+++ b/demo/component/index.ts
@@ -14,6 +14,7 @@ import Rectangle from './Rectangle';
 import Sector from './Sector';
 
 import LineChart from './LineChart';
+import LineChartSyncId from './LineChartSyncId';
 import AreaChart from './AreaChart';
 import BarChart from './BarChart';
 import ComposedChart from './ComposedChart';
@@ -33,6 +34,7 @@ import BugReproduce from './BugReproduce';
 export default {
   chartWrapper: {
     LineChart,
+    LineChartSyncId,
     AreaChart,
     BarChart,
     ComposedChart,

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -708,6 +708,7 @@ export interface CategoricalChartState {
 
 export interface CategoricalChartProps {
   syncId?: number | string;
+  syncMethod?: string,
   compact?: boolean;
   width?: number;
   height?: number;
@@ -930,6 +931,7 @@ export const generateCategoricalChart = ({
       barGap: 4,
       margin: { top: 5, right: 5, bottom: 5, left: 5 } as Margin,
       reverseStackOrder: false,
+      syncMethod: 'index',
       ...defaultProps,
     };
 
@@ -1271,7 +1273,7 @@ export const generateCategoricalChart = ({
     };
 
     handleReceiveSyncEvent = (cId: any, chartId: any, data: any) => {
-      const { syncId, layout } = this.props;
+      const { syncId, layout, syncMethod } = this.props;
       const { updateId } = this.state;
 
       if (syncId === cId && chartId !== this.uniqueChartId) {
@@ -1292,10 +1294,19 @@ export const generateCategoricalChart = ({
             ),
           });
         } else if (!_.isNil(data.activeTooltipIndex)) {
-          const { chartX, chartY, activeTooltipIndex } = data;
+          const { chartX, chartY } = data;
+          let { activeTooltipIndex } = data;
           const { offset, tooltipTicks } = this.state;
           if (!offset) {
             return;
+          }
+          if (syncMethod === 'value') {
+            // Set activeTooltipIndex to the index with the same value as data.activeLabel  
+            tooltipTicks.forEach(({ value }, index: number) => {
+              if (value === data.activeLabel) {
+                activeTooltipIndex = index;
+              }
+            });
           }
           const viewBox: CartesianViewBox = { ...offset, x: offset.left, y: offset.top };
           // When a categotical chart is combined with another chart, the value of chartX
@@ -1311,7 +1322,7 @@ export const generateCategoricalChart = ({
               }
             : originCoordinate;
 
-          this.setState({ ...data, activeLabel, activeCoordinate, activePayload });
+          this.setState({ ...data, activeLabel, activeCoordinate, activePayload, activeTooltipIndex:activeTooltipIndex });
         } else {
           this.setState(data);
         }

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1302,7 +1302,7 @@ export const generateCategoricalChart = ({
           }
           if (syncMethod === 'value') {
             // Set activeTooltipIndex to the index with the same value as data.activeLabel  
-            tooltipTicks.forEach(({ value }, index: number) => {
+            tooltipTicks.forEach(({ value }: TickItem, index: number) => {
               if (value === data.activeLabel) {
                 activeTooltipIndex = index;
               }

--- a/test/specs/chart/LineChartSpec.js
+++ b/test/specs/chart/LineChartSpec.js
@@ -508,3 +508,141 @@ describe('<LineChart /> - Pure Rendering with legend', () => {
   });
 
 });
+
+describe("<LineChart /> - Rendering two line charts with syncId", () => {
+  const margin = { top: 20, right: 20, bottom: 20, left: 20 };
+  const height = 400;
+  const width = 400;
+
+  // Reversed of data
+  const data2 = [
+    { name: "Page F", uv: 189, pv: 4800, amt: 2400 },
+    { name: "Page E", uv: 278, pv: 3908, amt: 2400 },
+    { name: "Page D", uv: 200, pv: 9800, amt: 2400 },
+    { name: "Page C", uv: 300, pv: 1398, amt: 2400 },
+    { name: "Page B", uv: 300, pv: 4567, amt: 2400 },
+    { name: "Page A", uv: 400, pv: 2400, amt: 2400 },
+  ];
+
+  it("should show tooltips for both charts synced by index on MouseEnter and hide on MouseLeave", () => {    
+    const ActiveDot = ({ cx, cy }) =>
+    <circle cx={cx} cy={cy} r={10} className="customized-active-dot" />;
+
+    const chart1 = (
+      <LineChart width={width} height={height} data={data} margin={margin} syncId="test">
+        <Line activeDot={<ActiveDot />} type="monotone" dataKey="uv" stroke="#ff7300" />
+        <Tooltip />
+        <XAxis dataKey="name" />
+      </LineChart>
+    );
+
+    const chart2 = (
+      <LineChart width={width} height={height} data={data2} margin={margin} syncId="test">
+        <Line activeDot={<ActiveDot />} type="monotone" dataKey="uv" stroke="#ff7300" />
+        <Tooltip />
+        <XAxis dataKey="name" />
+      </LineChart>
+    );
+
+    const wrapper = mount(
+      <div>
+        {chart1}
+        {chart2}
+      </div>
+    );
+
+    const chartWidth = width - margin.left - margin.right;
+    const dotSpacing = chartWidth / (data.length - 1);
+
+    // simulate entering just past Page A of Chart1 to test snapping of the cursor line
+    expect(
+      wrapper.find(".recharts-tooltip-cursor").hostNodes().length
+    ).to.equal(0);
+    wrapper.find(LineChart).at(0).simulate("mouseEnter", {
+        pageX: margin.left + 0.1 * dotSpacing,
+        pageY: height / 2,
+      });
+
+    // There are two tooltips - one for each LineChart as they have the same syncId
+    const tooltipCursors = wrapper.find(".recharts-tooltip-cursor").hostNodes();
+    expect(tooltipCursors.length).to.equal(2);
+
+    const tooltipsValueWrapper = wrapper.find(".recharts-tooltip-item-value");
+
+    // make sure tooltips display the correct values, i.e. the value of the first item in the data
+    expect(tooltipsValueWrapper.at(0).text()).to.equal("400");
+    expect(tooltipsValueWrapper.at(1).text()).to.equal("189"); 
+
+    // Check the activeDots are highlighted
+    const activeDotNodes = wrapper.find(".recharts-active-dot").hostNodes();
+    expect(activeDotNodes.length).to.equal(2);
+
+    const activeDotWrapper = wrapper.find(ActiveDot);
+    expect(activeDotWrapper.at(0).props().value).to.equal(400);
+    expect(activeDotWrapper.at(1).props().value).to.equal(189); 
+ 
+    // simulate leaving the area
+    wrapper.find(LineChart).at(0).simulate("mouseLeave");
+    expect(wrapper.find(".recharts-tooltip-cursor").hostNodes.length).to.equal(0);
+  });
+
+  it("should show tooltips using syncMethod: 'value' for both charts on MouseEnter and hide on MouseLeave", () => {
+    const ActiveDot = ({ cx, cy }) =>
+    <circle cx={cx} cy={cy} r={10} className="customized-active-dot" />;
+
+    const chart1 = (
+      <LineChart width={width} height={height} data={data} margin={margin} syncId="test" syncMethod="value">
+        <Line activeDot={<ActiveDot />} type="monotone" dataKey="uv" stroke="#ff7300" />
+        <Tooltip />
+        <XAxis dataKey="name" />
+      </LineChart>
+    );
+    const chart2 = (
+      <LineChart width={width} height={height} data={data2} margin={margin} syncId="test" syncMethod="value">
+        <Line activeDot={<ActiveDot />} type="monotone" dataKey="uv" stroke="#ff7300" />
+        <Tooltip />
+        <XAxis dataKey="name" />
+      </LineChart>
+    );
+    const wrapper = mount(
+      <div>
+        {chart1}
+        {chart2}
+      </div>
+    );
+
+    const chartWidth = width - margin.left - margin.right;
+    const dotSpacing = chartWidth / (data.length - 1);
+
+    // simulate entering just past Page A of Chart1 to test snapping of the cursor line
+    expect(
+      wrapper.find(".recharts-tooltip-cursor").hostNodes().length
+    ).to.equal(0);
+    wrapper.find(LineChart).at(0).simulate("mouseEnter", {
+        pageX: margin.left + 0.1 * dotSpacing,
+        pageY: height / 2,
+      });
+
+    // There are two tooltips - one for each LineChart as they have the same syncId
+    let tooltipCursors = wrapper.find(".recharts-tooltip-cursor").hostNodes();
+    expect(tooltipCursors.length).to.equal(2);
+
+    const tooltipsValueWrapper = wrapper.find(".recharts-tooltip-item-value");
+
+    // make sure tooltips display the correct values, synced by data value
+    expect(tooltipsValueWrapper.at(0).text()).to.equal("400");
+    expect(tooltipsValueWrapper.at(1).text()).to.equal("400");    
+
+    // Check the activeDots are highlighted
+    const activeDotNodes = wrapper.find(".recharts-active-dot").hostNodes();
+    expect(activeDotNodes.length).to.equal(2);
+
+    const activeDotWrapper = wrapper.find(ActiveDot);
+    expect(activeDotWrapper.at(0).props().value).to.equal(400);
+    expect(activeDotWrapper.at(1).props().value).to.equal(400); 
+
+    // simulate leaving the area
+    wrapper.find(LineChart).at(0).simulate("mouseLeave");
+    expect(wrapper.find(".recharts-tooltip-cursor").hostNodes.length).to.equal(0);
+  });
+});


### PR DESCRIPTION
syncMethod can have: "index" (default value) or "value"

If syncMethod is equal to "value", set activeTooltipIndex to the index
with the same value as data.activeLabel.
Save activeTooltipIndex in the state as it is used by activeDot

Add two tests to check two Line Charts with the same syncId and
syncMethod not defined or syncMethod = "value"
Add a demo example where you can switch syncMethod between index and
value - by default, syncMethod is null