### PR TITLE
Fix parameters passed to syncMethod calback function

### DIFF
--- a/demo/component/LineChartSyncId.tsx
+++ b/demo/component/LineChartSyncId.tsx
@@ -29,7 +29,7 @@ const initialState = {
 };
 
 // Example callback function that can be used to specify the algorithm
-const syncMethodFunction = (index: number, data: any) => index + 1;
+const syncMethodFunction = (_tooltipTicks: [], data: any) => data.activeTooltipIndex + 1;
 
 // eslint-disable-next-line import/no-default-export
 export default class Demo extends Component<any, any> {

--- a/src/chart/generateCategoricalChart.tsx
+++ b/src/chart/generateCategoricalChart.tsx
@@ -1533,7 +1533,7 @@ export const generateCategoricalChart = ({
         }
         if (typeof syncMethod === 'function') {
           // Call a callback function. If there is an application specific algorithm
-          activeTooltipIndex = syncMethod(activeTooltipIndex, data);
+          activeTooltipIndex = syncMethod(tooltipTicks, data);
         } else if (syncMethod === 'value') {
           // Set activeTooltipIndex to the index with the same value as data.activeLabel
           // For loop instead of findIndex because the latter is very slow in some browsers

--- a/test/specs/chart/LineChartSpec.js
+++ b/test/specs/chart/LineChartSpec.js
@@ -658,7 +658,7 @@ describe("<LineChart /> - Rendering two line charts with syncId", () => {
     const ActiveDot = ({ cx, cy }) =>
       <circle cx={cx} cy={cy} r={10} className="customized-active-dot" />;
 
-    const syncMethodFunction = index => index + 1;
+    const syncMethodFunction = (tooltipTicks, data) => data.activeTooltipIndex + 1;
 
     const chart1 = (
       <LineChart width={width} height={height} data={data} margin={margin} syncId="test" syncMethod={syncMethodFunction}>


### PR DESCRIPTION
If syncMethod is a function, the calback function should get access to tooltipTicks and data.